### PR TITLE
awesome-cli, src/cli.rs: Implement an RPC UNIX socket.

### DIFF
--- a/awesome-cli
+++ b/awesome-cli
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if !which socat > /dev/null 2>&1; then
+	echo awesome-cli: socat not installed >&2
+	exit 1
+fi
+
+(echo "$@") | socat UNIX-CONNECT:${HOME}/awesome_rpc -

--- a/src/main.rs
+++ b/src/main.rs
@@ -748,6 +748,7 @@ async fn start_ldk() {
 
 	// Start the CLI.
 	cli::poll_for_user_input(
+		Arc::clone(&logger),
 		Arc::clone(&invoice_payer),
 		Arc::clone(&peer_manager),
 		Arc::clone(&channel_manager),


### PR DESCRIPTION
Implement an RPC UNIX socket.

Tested by copying the processing loop and the new code into a new Rust project, replacing the `handle_one_user_input` function to recognize "help" and "quit", and running the new Rust project, then using the new `awesome-cli` script to send commands.  Works.

Does require `socat` to be installed because it is easier to just use it instead of implementing a new binary just for opening a socket connection and sending some text to it.